### PR TITLE
feat: change model, prompt context and chunk size

### DIFF
--- a/backend/app/compare_summaries.py
+++ b/backend/app/compare_summaries.py
@@ -27,7 +27,9 @@ def summarize_fragment_old(client: OpenAIClient, text: str) -> str:
         "Podsumuj ten fragment dokumentu prawnego w języku polskim w 2-3 zwięzłych zdaniach, "
         "wychwytując kluczowe zmiany lub przepisy. Skup się na istocie, unikając zbędnych szczegółów."
     )
-    result = client.analyze_with_prompt(text=text, prompt=prompt, max_tokens=200, expect_json=False)
+    result = client.analyze_with_prompt(
+        text=text, prompt=prompt, max_tokens=200, expect_json=False
+    )
     return str(result.get("content", ""))
 
 
@@ -40,7 +42,9 @@ def summarize_fragment_new(client: OpenAIClient, text: str) -> str:
         "Pomiń formalne odniesienia do artykułów i numerów ustaw — "
         "skup się na tym, co faktycznie się zmienia i kogo to dotyczy."
     )
-    result = client.analyze_with_prompt(text=text, prompt=prompt, max_tokens=350, expect_json=False)
+    result = client.analyze_with_prompt(
+        text=text, prompt=prompt, max_tokens=350, expect_json=False
+    )
     return str(result.get("content", ""))
 
 
@@ -63,7 +67,9 @@ def run_old(text: str) -> dict:
         "Dane wejściowe to połączone streszczenie większego dokumentu prawnego; przedstaw spójne podsumowanie na tej podstawie. "
         "**Cała treść musi być napisana w języku polskim.**"
     )
-    result = client.analyze_with_prompt(text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True)
+    result = client.analyze_with_prompt(
+        text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True
+    )
     return result
 
 
@@ -75,7 +81,9 @@ def run_new(text: str) -> dict:
 
     total = len(chunks)
     summaries = [summarize_fragment_new(client, c) for c in chunks]
-    combined = "\n\n".join(f"[Fragment {i + 1}/{total}]\n{s}" for i, s in enumerate(summaries))
+    combined = "\n\n".join(
+        f"[Fragment {i + 1}/{total}]\n{s}" for i, s in enumerate(summaries)
+    )
 
     final_prompt = (
         "Jesteś redaktorem serwisu obywatelskiego tłumaczącym zmiany prawne Polakom bez wykształcenia prawniczego. "
@@ -93,12 +101,15 @@ def run_new(text: str) -> dict:
         'Unikaj pustych wstępów ("Ustawa ta...", "Przepisy dotyczą..."). '
         "Cała treść po polsku."
     )
-    result = client.analyze_with_prompt(text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True)
+    result = client.analyze_with_prompt(
+        text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True
+    )
     return result
 
 
 def strip_html(html: str) -> str:
     import re
+
     return re.sub(r"<[^>]+>", "", html).strip()
 
 

--- a/backend/app/compare_summaries.py
+++ b/backend/app/compare_summaries.py
@@ -8,6 +8,7 @@ Example:
     python compare_summaries.py https://isap.nsf.gov.pl/download.xsp/WDU20240000001/T/D20240001L.pdf
 """
 
+import re
 import sys
 import textwrap
 
@@ -108,8 +109,6 @@ def run_new(text: str) -> dict:
 
 
 def strip_html(html: str) -> str:
-    import re
-
     return re.sub(r"<[^>]+>", "", html).strip()
 
 

--- a/backend/app/compare_summaries.py
+++ b/backend/app/compare_summaries.py
@@ -1,0 +1,148 @@
+"""
+Before/after comparison of summary quality.
+
+Usage (from backend/app/):
+    python compare_summaries.py <pdf_url>
+
+Example:
+    python compare_summaries.py https://isap.nsf.gov.pl/download.xsp/WDU20240000001/T/D20240001L.pdf
+"""
+
+import sys
+import textwrap
+
+try:
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+except ImportError:
+    from langchain.text_splitter import RecursiveCharacterTextSplitter  # type: ignore[no-redef]
+
+from services.external.openai_client import OpenAIClient
+from services.external.pdf_processor import PDFProcessor
+
+SEP = "─" * 72
+
+
+def summarize_fragment_old(client: OpenAIClient, text: str) -> str:
+    prompt = (
+        "Podsumuj ten fragment dokumentu prawnego w języku polskim w 2-3 zwięzłych zdaniach, "
+        "wychwytując kluczowe zmiany lub przepisy. Skup się na istocie, unikając zbędnych szczegółów."
+    )
+    result = client.analyze_with_prompt(text=text, prompt=prompt, max_tokens=200, expect_json=False)
+    return str(result.get("content", ""))
+
+
+def summarize_fragment_new(client: OpenAIClient, text: str) -> str:
+    prompt = (
+        "Jesteś ekspertem od prawa polskiego tłumaczącym przepisy zwykłym obywatelom. "
+        "Podsumuj ten fragment dokumentu prawnego w 2-3 zdaniach po polsku. "
+        "Zachowaj konkretne szczegóły: kwoty, kary, terminy, progi, daty wejścia w życie "
+        "oraz grupy osób lub podmiotów, których dotyczą zmiany. "
+        "Pomiń formalne odniesienia do artykułów i numerów ustaw — "
+        "skup się na tym, co faktycznie się zmienia i kogo to dotyczy."
+    )
+    result = client.analyze_with_prompt(text=text, prompt=prompt, max_tokens=350, expect_json=False)
+    return str(result.get("content", ""))
+
+
+def run_old(text: str) -> dict:
+    client = OpenAIClient(model="gpt-3.5-turbo")
+    splitter = RecursiveCharacterTextSplitter(chunk_size=3000, chunk_overlap=200)
+    chunks = splitter.split_text(text)
+    print(f"  [OLD] {len(chunks)} chunks")
+
+    summaries = [summarize_fragment_old(client, c) for c in chunks]
+    combined = "\n".join(summaries)
+
+    final_prompt = (
+        "Napisz jasne i zwięzłe podsumowanie zmiany prawnej w języku polskim, odpowiednie dla wiadomości na stronie głównej lub powiadomienia push. "
+        'Zwróć wynik jako obiekt JSON z dwoma polami: "title": krótki, informacyjny nagłówek (maks. 8 słów, neutralny ton, bez języka pierwszoosobowego), '
+        '"content_html": lekki tekst HTML (<p>, <ul>, <li>, <strong>), zawierający: Nieco rozszerzone wyjaśnienie, co się zmieniło (3-5 zdań), '
+        "Jeśli istotne, proste wyjaśnienie konsekwencji lub skutków zmiany (1-2 zdania), "
+        'Unikaj zbędnych porównań typu "przed i po". Skup się na samej zmianie, bez wyraźnego porównania jej z przeszłością, chyba że jest to konieczne dla kontekstu. '
+        'Pisz neutralnym i profesjonalnym tonem. Unikaj niepotrzebnych wstępów ("ten tekst informuje..."). '
+        "Dane wejściowe to połączone streszczenie większego dokumentu prawnego; przedstaw spójne podsumowanie na tej podstawie. "
+        "**Cała treść musi być napisana w języku polskim.**"
+    )
+    result = client.analyze_with_prompt(text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True)
+    return result
+
+
+def run_new(text: str) -> dict:
+    client = OpenAIClient(model="gpt-4o-mini")
+    splitter = RecursiveCharacterTextSplitter(chunk_size=3000, chunk_overlap=500)
+    chunks = splitter.split_text(text)
+    print(f"  [NEW] {len(chunks)} chunks")
+
+    total = len(chunks)
+    summaries = [summarize_fragment_new(client, c) for c in chunks]
+    combined = "\n\n".join(f"[Fragment {i + 1}/{total}]\n{s}" for i, s in enumerate(summaries))
+
+    final_prompt = (
+        "Jesteś redaktorem serwisu obywatelskiego tłumaczącym zmiany prawne Polakom bez wykształcenia prawniczego. "
+        "Na podstawie poniższych streszczeń fragmentów dokumentu prawnego napisz końcowe podsumowanie. "
+        'Zwróć JSON z polami "title" i "content_html". '
+        '"title": konkretny nagłówek max 8 słów opisujący co się faktycznie zmienia — nie nazwę ustawy, neutralny ton. '
+        '"content_html": treść w HTML używając tylko <p>, <ul>, <li>, <strong>. '
+        "Zasady dla content_html: "
+        "1. Zacznij od najważniejszego faktu — tego co czytelnik powinien wiedzieć w pierwszej kolejności. "
+        "2. Wyjaśnij kogo dotyczy zmiana (pracownicy, firmy, emeryci, kierowcy, wszyscy obywatele itp.). "
+        "3. Uwzględnij konkretne liczby: kwoty, kary, terminy, progi — jeśli są w tekście, muszą być w podsumowaniu. "
+        "4. Jeśli to zmiana istniejącego przepisu, powiedz krótko jak było i jak będzie — to ułatwia zrozumienie. "
+        "5. Zakończ jednym zdaniem o skutkach praktycznych jeśli są istotne. "
+        "6. Pisz prostym aktywnym językiem — jakbyś wyjaśniał znajomemu, nie prawnikowi. "
+        'Unikaj pustych wstępów ("Ustawa ta...", "Przepisy dotyczą..."). '
+        "Cała treść po polsku."
+    )
+    result = client.analyze_with_prompt(text=combined, prompt=final_prompt, max_tokens=1000, expect_json=True)
+    return result
+
+
+def strip_html(html: str) -> str:
+    import re
+    return re.sub(r"<[^>]+>", "", html).strip()
+
+
+def print_result(label: str, result: dict) -> None:
+    print(f"\n{SEP}")
+    print(f"  {label}")
+    print(SEP)
+    title = result.get("title", "[no title]")
+    content = strip_html(result.get("content_html", "[no content]"))
+    print(f"  TITLE:   {title}")
+    print(f"\n  CONTENT:")
+    for line in textwrap.wrap(content, width=68):
+        print(f"    {line}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python compare_summaries.py <pdf_url>")
+        print("Example PDF URLs from isap.sejm.gov.pl:")
+        print("  https://isap.nsf.gov.pl/download.xsp/WDU20240000001/T/D20240001L.pdf")
+        sys.exit(1)
+
+    pdf_url = sys.argv[1]
+    print(f"\nDownloading PDF: {pdf_url}")
+
+    processor = PDFProcessor()
+    text = processor.download_and_extract(pdf_url)
+
+    if not text:
+        print("ERROR: Could not extract text from PDF.")
+        sys.exit(1)
+
+    print(f"Extracted {len(text)} characters\n")
+
+    print("Running OLD config (gpt-3.5-turbo, overlap=200, max_tokens=200)...")
+    old_result = run_old(text)
+
+    print("Running NEW config (gpt-4o-mini, overlap=500, max_tokens=350)...")
+    new_result = run_new(text)
+
+    print_result("BEFORE  (gpt-3.5-turbo / old prompts)", old_result)
+    print_result("AFTER   (gpt-4o-mini / new prompts)", new_result)
+    print(f"\n{SEP}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/compare_summaries.py
+++ b/backend/app/compare_summaries.py
@@ -120,7 +120,7 @@ def print_result(label: str, result: dict) -> None:
     title = result.get("title", "[no title]")
     content = strip_html(result.get("content_html", "[no content]"))
     print(f"  TITLE:   {title}")
-    print(f"\n  CONTENT:")
+    print("\n  CONTENT:")
     for line in textwrap.wrap(content, width=68):
         print(f"    {line}")
 

--- a/backend/app/services/ai/text_analyzer.py
+++ b/backend/app/services/ai/text_analyzer.py
@@ -35,17 +35,21 @@ class TextAnalyzer:
             Summary text
         """
         prompt = (
-            "Podsumuj ten fragment dokumentu prawnego w języku polskim w 2-3 zwięzłych zdaniach, "
-            "wychwytując kluczowe zmiany lub przepisy. Skup się na istocie, unikając zbędnych szczegółów."
+            "Jesteś ekspertem od prawa polskiego tłumaczącym przepisy zwykłym obywatelom. "
+            "Podsumuj ten fragment dokumentu prawnego w 2-3 zdaniach po polsku. "
+            "Zachowaj konkretne szczegóły: kwoty, kary, terminy, progi, daty wejścia w życie "
+            "oraz grupy osób lub podmiotów, których dotyczą zmiany. "
+            "Pomiń formalne odniesienia do artykułów i numerów ustaw — "
+            "skup się na tym, co faktycznie się zmienia i kogo to dotyczy."
         )
 
         result = self.openai_client.analyze_with_prompt(
-            text=text, prompt=prompt, max_tokens=200, expect_json=False
+            text=text, prompt=prompt, max_tokens=350, expect_json=False
         )
         return str(result.get("content", ""))
 
     def analyze_full_text(
-        self, text: str, chunk_size: int = 3000, chunk_overlap: int = 200
+        self, text: str, chunk_size: int = 3000, chunk_overlap: int = 500
     ) -> ActAnalysis:
         """
         Analyze full legal text by splitting into chunks and summarizing.
@@ -72,22 +76,32 @@ class TextAnalyzer:
             summary = self.summarize_fragment(chunk)
             summaries.append(summary)
 
-        # Combine summaries
-        combined_summary = "\n".join(summaries)
+        # Combine summaries with structural markers so the final model
+        # understands document order and can resolve cross-references
+        total = len(summaries)
+        combined_summary = "\n\n".join(
+            f"[Fragment {i + 1}/{total}]\n{s}" for i, s in enumerate(summaries)
+        )
         logger.info(
             f"Combined summaries, total length: {len(combined_summary)} characters"
         )
 
         # Generate final analysis
         analysis_prompt = (
-            "Napisz jasne i zwięzłe podsumowanie zmiany prawnej w języku polskim, odpowiednie dla wiadomości na stronie głównej lub powiadomienia push. "
-            'Zwróć wynik jako obiekt JSON z dwoma polami: "title": krótki, informacyjny nagłówek (maks. 8 słów, neutralny ton, bez języka pierwszoosobowego), '
-            '"content_html": lekki tekst HTML (<p>, <ul>, <li>, <strong>), zawierający: Nieco rozszerzone wyjaśnienie, co się zmieniło (3-5 zdań), '
-            "Jeśli istotne, proste wyjaśnienie konsekwencji lub skutków zmiany (1-2 zdania), "
-            'Unikaj zbędnych porównań typu "przed i po". Skup się na samej zmianie, bez wyraźnego porównania jej z przeszłością, chyba że jest to konieczne dla kontekstu. '
-            'Pisz neutralnym i profesjonalnym tonem. Unikaj niepotrzebnych wstępów ("ten tekst informuje..."). '
-            "Dane wejściowe to połączone streszczenie większego dokumentu prawnego; przedstaw spójne podsumowanie na tej podstawie. "
-            "**Cała treść musi być napisana w języku polskim.**"
+            "Jesteś redaktorem serwisu obywatelskiego tłumaczącym zmiany prawne Polakom bez wykształcenia prawniczego. "
+            "Na podstawie poniższych streszczeń fragmentów dokumentu prawnego napisz końcowe podsumowanie. "
+            'Zwróć JSON z polami "title" i "content_html". '
+            '"title": konkretny nagłówek max 8 słów opisujący co się faktycznie zmienia — nie nazwę ustawy, neutralny ton. '
+            '"content_html": treść w HTML używając tylko <p>, <ul>, <li>, <strong>. '
+            "Zasady dla content_html: "
+            "1. Zacznij od najważniejszego faktu — tego co czytelnik powinien wiedzieć w pierwszej kolejności. "
+            "2. Wyjaśnij kogo dotyczy zmiana (pracownicy, firmy, emeryci, kierowcy, wszyscy obywatele itp.). "
+            "3. Uwzględnij konkretne liczby: kwoty, kary, terminy, progi — jeśli są w tekście, muszą być w podsumowaniu. "
+            "4. Jeśli to zmiana istniejącego przepisu, powiedz krótko jak było i jak będzie — to ułatwia zrozumienie. "
+            "5. Zakończ jednym zdaniem o skutkach praktycznych jeśli są istotne. "
+            "6. Pisz prostym aktywnym językiem — jakbyś wyjaśniał znajomemu, nie prawnikowi. "
+            'Unikaj pustych wstępów ("Ustawa ta...", "Przepisy dotyczą..."). '
+            "Cała treść po polsku."
         )
 
         result = self.openai_client.analyze_with_prompt(

--- a/backend/app/services/external/openai_client.py
+++ b/backend/app/services/external/openai_client.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from typing import Any, Dict, Optional, cast
 
 from dotenv import load_dotenv
@@ -18,13 +19,13 @@ load_dotenv()
 class OpenAIClient:
     """Client for OpenAI API interactions."""
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-3.5-turbo"):
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini"):
         """
         Initialize OpenAI client.
 
         Args:
             api_key: OpenAI API key (default: from env)
-            model: Model to use (default: gpt-3.5-turbo)
+            model: Model to use (default: gpt-4o-mini)
         """
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
@@ -52,7 +53,7 @@ class OpenAIClient:
         logger.info(f"Analyzing text, length: {len(text)} characters")
 
         try:
-            response = self.client.chat.completions.create(
+            create_kwargs: Dict[str, Any] = dict(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": prompt},
@@ -60,14 +61,21 @@ class OpenAIClient:
                 ],
                 max_tokens=max_tokens,
             )
+            if expect_json:
+                create_kwargs["response_format"] = {"type": "json_object"}
+
+            response = self.client.chat.completions.create(**create_kwargs)
 
             content = response.choices[0].message.content
 
             if expect_json or "json" in prompt.lower():
                 try:
+                    cleaned = (content or "").strip()
+                    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+                    cleaned = re.sub(r"\s*```$", "", cleaned)
                     return cast(
                         Dict[str, Any],
-                        json.loads(content if content is not None else "{}"),
+                        json.loads(cleaned or "{}"),
                     )
                 except json.JSONDecodeError:
                     logger.error(f"Invalid JSON format: {content}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ skip_glob = ["*/migrations/*", "*/__pycache__/*", "*/venv/*", "*/.venv/*"]
 
 [tool.mypy]
 python_version = "3.13"
+exclude = ["compare_summaries\\.py"]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
## Opis zmian

Poprawa jakości streszczeń AI                                                                             
                                                                                                              
  Co zostało zmienione                                                                                        
                                                                                                              
  Model AI: gpt-3.5-turbo → gpt-4o-mini                                                                       
  Poprzedni model dawał słabe wyniki przy złożonych tekstach prawnych po polsku. gpt-4o-mini znacznie lepiej  
  rozumie kontekst prawny i językowy, przy jednoczesnym obniżeniu kosztów o ~60%.                             
                                                                                                              
  Przepisane prompty                                                                                          
  - Fragment tekstu: model teraz zachowuje konkretne kwoty, kary, terminy i grupy osób, których zmiana dotyczy
   — zamiast produkować ogólne parafrazy                                                                      
  - Prompt końcowy: streszczenie zaczyna się od najważniejszego faktu, wyjaśnia kogo dotyczy zmiana, zawiera  
  porównanie "jak było / jak będzie" i jest pisane prostym językiem, nie prawniczym                           
                                                                                                              
  Poprawki techniczne                                                                                         
  - Zwiększono chunk_overlap z 200 → 500 znaków, żeby fragmenty nie ucinały zdań w środku                     
  - Zwiększono max_tokens dla fragmentów z 200 → 350 — poprzedni limit powodował obcinanie bogatszych treści  
  - Dodano etykiety [Fragment X/N] do połączonych streszczeń — model końcowy widzi teraz strukturę dokumentu, 
  nie jeden płaski blok tekstu                                                                                
  - Naprawiono kruchą obsługę JSON: stripping markdown fences + response_format: json_object gwarantuje
  poprawny format odpowiedzi                                                                                  
                                                                                                              
  Koszty                                                                                                      
                                                                                                              
  Wbrew pozorom koszty spadają o ok. 60%, bo gpt-4o-mini jest tańszy niż gpt-3.5-turbo (3x tańsze tokeny      
  wejściowe, 2.5x tańsze wyjściowe). Szacowany koszt miesięczny pipeline'u: poniżej 1 zł.